### PR TITLE
Refactor support modules for cleaner ODE solver playground

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -1,6 +1,6 @@
-from solver import np, npt
-
-from numpy import sin, cos
+import numpy as np
+import numpy.typing as npt
+from numpy import cos, sin
 
 
 def f_exponential_system(y) -> npt.NDArray:
@@ -21,9 +21,9 @@ def f_logistic(y) -> npt.NDArray:
     return y * (1 - y)
 
 
-a = 2  # pendulum length [m]
-m = 1  # mass [kg]
-g = 10  # gravitational acceleration [m/s^2]
+a = 2.0  # pendulum length [m]
+m = 1.0  # mass [kg]
+g = 10.0  # gravitational acceleration [m/s^2]
 
 
 def f_double_pendulum_v0(y) -> npt.NDArray:
@@ -74,11 +74,6 @@ def f_double_pendulum_v0(y) -> npt.NDArray:
     result[0] = 1
 
     return result
-
-
-a = 2.0
-g = 10.0
-
 
 def f_double_pendulum_v1(y) -> npt.NDArray:
     """State y = [t, theta=C, phi=D, theta_dot=A, phi_dot=B]

--- a/grapher.py
+++ b/grapher.py
@@ -1,35 +1,37 @@
 import matplotlib.pyplot as plt
-from solver import np, ODESolve
+import numpy as np
+
+from solver import ODESolve
 
 
-def run_methods(the_function, methods, h_val, nsteps, y0):
-    """Run ODE solvers for each method and return results."""
+def solve_methods(ode_func, methods, h, n_steps, y0):
+    """Run *ODEFunc* with each method and return the trajectories."""
     return [
-        ODESolve(h=h_val, Nsteps=nsteps, y0=y0, f=the_function, method=m)
+        ODESolve(h=h, Nsteps=n_steps, y0=y0, f=ode_func, method=m)
         for m in methods
     ]
 
 
-def print_results(steps, y0, final_t, solutions, labels, t0):
+def print_summary(n_steps, y0, final_t, solutions, labels, t0):
     """Print step info and final values for each method."""
-    print(f"Steps {steps}, Initial y {y0} Initial t {t0} Final t {final_t}")
+    print(f"Steps {n_steps}, Initial y {y0} Initial t {t0} Final t {final_t}")
     for label, sol in zip(labels, solutions):
         print(f"Final {label}: {sol[-1]}")
 
 
-def plot_solutions(exact_t, solutions, labels):
+def plot_solutions(t, solutions, labels):
     """Plot solutions using matplotlib."""
     fig, ax = plt.subplots()
     for sol, label in zip(solutions, labels):
-        ax.plot(exact_t, sol, label=label)
+        ax.plot(t, sol, label=label)
     ax.legend()
     ax.set_title("y(t)")
     plt.show()
 
 
-def solve_and_plot(labels, the_function, methods, h_val, nsteps, y0, t0):
+def solve_and_plot(labels, ode_func, methods, h, n_steps, y0, t0):
     """Run, print, and plot ODE solutions for all methods."""
-    solutions = run_methods(the_function, methods, h_val, nsteps, y0)
-    exact_t = np.linspace(t0, h_val * nsteps, nsteps + 1, endpoint=True)
-    print_results(nsteps, y0, exact_t[-1], solutions, labels, t0)
-    plot_solutions(exact_t, solutions, labels)
+    solutions = solve_methods(ode_func, methods, h, n_steps, y0)
+    t = np.linspace(t0, h * n_steps, n_steps + 1, endpoint=True)
+    print_summary(n_steps, y0, t[-1], solutions, labels, t0)
+    plot_solutions(t, solutions, labels)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,7 @@
-from solver import ODEFunc, npt, np
+import numpy as np
+import numpy.typing as npt
+
+from solver import ODEFunc
 from rkgen import ExplicitRK_method_generator
 from grapher import solve_and_plot
 from functions import f_exponential, f_double_pendulum_v0, f_double_pendulum_v1
@@ -18,19 +21,19 @@ def main():
 
     RK4 = ExplicitRK_method_generator(A_matrix=A_matrix, b_vector=b_vector)
 
-    Steps = 4
-    Final = 1
-    h_val = Final / Steps
+    steps = 4
+    final = 1
+    h_val = final / steps
     y0 = np.array([1])
 
     print("dy/dy = t, t0 = 0 y(t0)=1, solution y(t) = e^t, t_final = 1")
 
     solve_and_plot(
         labels=["Euler", "RK4"],
-        the_function=f_exponential,
+        ode_func=f_exponential,
         methods=[euler_method, RK4],
-        h_val=h_val,
-        nsteps=Steps,
+        h=h_val,
+        n_steps=steps,
         y0=y0,
         t0=0,
     )
@@ -41,9 +44,9 @@ def double_pendulum_sanity_check():
     print("Double Pendulum Sanity Check, v0, v1 (should be same)")
     print("y = [t, θ, φ, θ̇, φ̇]")
     print(f"v0: f({y0}) = {f_double_pendulum_v0(y0)}")
-    print(f"v1: f({y0}) = {f_double_pendulum_v0(y0)}")
+    print(f"v1: f({y0}) = {f_double_pendulum_v1(y0)}")
 
 
 if __name__ == "__main__":
-    # main()
+    main()
     double_pendulum_sanity_check()

--- a/solver.py
+++ b/solver.py
@@ -1,27 +1,27 @@
 from typing import Protocol
+
 import numpy as np
 import numpy.typing as npt
 
 
-def enforce_1d(x):
-    """Ensure input is a 1D numpy array."""
-    x = np.asarray(x)
-    if x.ndim == 0:
-        return x[np.newaxis]
-    elif x.ndim == 1:
-        return x
-    elif x.ndim == 2:
-        if x.shape[0] == 1 or x.shape[1] == 1:
-            return x.ravel()
-    raise ValueError(f"Expected scalar or 1D array, got shape {x.shape}")
+def enforce_1d(x: npt.ArrayLike) -> npt.NDArray:
+    """Return *x* as a contiguous 1‑D array."""
+    arr = np.asarray(x)
+    if arr.ndim == 0:
+        return arr[np.newaxis]
+    if arr.ndim == 1:
+        return arr
+    if arr.ndim == 2 and (arr.shape[0] == 1 or arr.shape[1] == 1):
+        return arr.ravel()
+    raise ValueError(f"Expected scalar or 1D array, got shape {arr.shape}")
 
 
-def is_strictly_lower_triangular_and_sbys(A, s):
-    """Check if A is strictly lower triangular and square of size s."""
-    A = np.asarray(A)
-    if A.shape != (s, s):
+def is_strictly_lower_triangular(A: npt.ArrayLike, size: int) -> bool:
+    """Return True if *A* is a strictly lower triangular square matrix."""
+    mat = np.asarray(A)
+    if mat.shape != (size, size):
         return False
-    return np.allclose(A, np.tril(A, k=-1))
+    return np.allclose(mat, np.tril(mat, k=-1))
 
 
 class ODEFunc(Protocol):


### PR DESCRIPTION
## Summary
- streamline imports and delete obsolete 1D RK generator
- standardize constants and numpy usage across helpers
- tidy plotting utilities and demo script while fixing double pendulum check

## Testing
- `python -m py_compile rkgen.py solver.py grapher.py functions.py main.py`
- `MPLBACKEND=Agg python main.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy matplotlib` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a07e0b1998833287a462a0d0cc9d49